### PR TITLE
Add osmctools

### DIFF
--- a/packages/osmctools/build.sh
+++ b/packages/osmctools/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_VERSION=0.9
 TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/${TERMUX_PKG_VERSION}/osmctools-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2f5298be5b4ba840a04f360c163849b34a31386ccd287657885e21268665f413
+TERMUX_PKG_DEPENDS="zlib"
 
 termux_step_pre_configure () {
 	autoreconf --install

--- a/packages/osmctools/build.sh
+++ b/packages/osmctools/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Simple tools for OpenStreetMap processing"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_VERSION=0.9
 TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/${TERMUX_PKG_VERSION}/osmctools-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=af755766fd7168a16727aba122f8e427542c4c52669be1f463002d19c4c04ab1
+TERMUX_PKG_SHA256=2f5298be5b4ba840a04f360c163849b34a31386ccd287657885e21268665f413
 
 termux_step_pre_configure () {
 	autoreconf --install

--- a/packages/osmctools/build.sh
+++ b/packages/osmctools/build.sh
@@ -1,11 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://gitlab.com/osm-c-tools/osmctools
-TERMUX_PKG_DESCRIPTION="Simple tools for OpenStreetMap processing."
-TERMUX_PKG_LICENSE="agplv3"
+TERMUX_PKG_DESCRIPTION="Simple tools for OpenStreetMap processing"
+TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_VERSION=0.9
-TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/master/osmctools-master.tar.gz
+TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/${TERMUX_PKG_VERSION}/osmctools-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=af755766fd7168a16727aba122f8e427542c4c52669be1f463002d19c4c04ab1
-TERMUX_PKG_BUILD_IN_SRC=yes
 
-termux_step_post_extract_package () {
-	mv COPYING LICENSE
+termux_step_pre_configure () {
+	autoreconf --install
 }

--- a/packages/osmctools/build.sh
+++ b/packages/osmctools/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=https://gitlab.com/osm-c-tools/osmctools
+TERMUX_PKG_DESCRIPTION="Simple tools for OpenStreetMap processing."
+TERMUX_PKG_LICENSE="agplv3"
+TERMUX_PKG_VERSION=0.9
+TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/master/osmctools-master.tar.gz
+TERMUX_PKG_SHA256=af755766fd7168a16727aba122f8e427542c4c52669be1f463002d19c4c04ab1

--- a/packages/osmctools/build.sh
+++ b/packages/osmctools/build.sh
@@ -4,3 +4,7 @@ TERMUX_PKG_LICENSE="agplv3"
 TERMUX_PKG_VERSION=0.9
 TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/master/osmctools-master.tar.gz
 TERMUX_PKG_SHA256=af755766fd7168a16727aba122f8e427542c4c52669be1f463002d19c4c04ab1
+
+termux_step_post_extract_package () {
+	mv COPYING LICENSE
+}

--- a/packages/osmctools/build.sh
+++ b/packages/osmctools/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="agplv3"
 TERMUX_PKG_VERSION=0.9
 TERMUX_PKG_SRCURL=https://gitlab.com/osm-c-tools/osmctools/-/archive/master/osmctools-master.tar.gz
 TERMUX_PKG_SHA256=af755766fd7168a16727aba122f8e427542c4c52669be1f463002d19c4c04ab1
+TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_post_extract_package () {
 	mv COPYING LICENSE


### PR DESCRIPTION
`osmctools` is a package for tools commonly required for processing OpenStreetMap (OSM) data.
Building is to be tested after opening a pull request only, so it may take some time to fix it.

Thanks