### PR TITLE
Mv texlive from main repository

### DIFF
--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -1,0 +1,361 @@
+TERMUX_PKG_HOMEPAGE=https://www.tug.org/texlive/
+TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system."
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_VERSION=20200406
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-texmf.tar.xz
+TERMUX_PKG_SHA256=0aa97e583ecfd488e1dc60ff049fec073c1e22dfe7de30a3e4e8c851bb875a95
+TERMUX_PKG_DEPENDS="perl, texlive-bin (>= 20200406-1)"
+TERMUX_PKG_CONFLICTS="texlive (<< 20170524-5), texlive-bin (<< 20190410), texlive-tlmgr (<< 20190410), texlive-binextra (<= 20190410-2), texlive-langother (<= 20190410-2), texlive-langgerman (<= 20190410-2), texlive-plaingeneric (<= 20190410-2), texlive-fontsrecommended (<= 20190410-2), texlive-latexrecommended (<= 20190410-2), texlive-latexextra (<= 20190410-2), texlive-xetex (<= 20190410-2)"
+TERMUX_PKG_REPLACES="texlive-bin (<< 20190410), texlive-tlmgr (<< 20190410)"
+TERMUX_PKG_BREAKS="texlive-installer"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_HAS_DEBUG=false
+TERMUX_PKG_BUILD_IN_SRC=true
+
+TL_ROOT=$TERMUX_PREFIX/share/texlive
+TL_BINDIR=$TERMUX_PREFIX/bin
+
+termux_step_post_extract_package() {
+	cd $TERMUX_PKG_CACHEDIR
+	termux_download ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/install-tl-unx.tar.gz \
+			install-tl-unx.tar.gz \
+			7c90a50e55533d57170cbc7c0370a010019946eb18570282948e1af6f809382d
+
+	tar xf install-tl-unx.tar.gz
+	mv install-tl-*/install-tl \
+	   install-tl-*/LICENSE.CTAN \
+	   install-tl-*/LICENSE.TL \
+	   install-tl-*/release-texlive.txt \
+	   install-tl-*/tlpkg \
+	   $TERMUX_PKG_SRCDIR/
+
+	# Download texlive.tlpdb, parse to get file lists and include in texlive-full.
+	termux_download ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-tlpdb-full.tar.gz \
+			texlive-${TERMUX_PKG_VERSION}-tlpdb-full.tar.gz \
+			2990a8d275506c297b2239a1b4c5d9a9ec0d18cf12ff9a6a33924cf2e3838ed4
+
+	tar xf texlive-${TERMUX_PKG_VERSION}-tlpdb-full.tar.gz
+	mv texlive.tlpdb $TERMUX_PKG_TMPDIR
+}
+
+termux_step_make() {
+	sed -i "s% RELOC/% texmf-dist/%g" $TERMUX_PKG_TMPDIR/texlive.tlpdb
+	mkdir -p $TL_ROOT
+	cp -r $TERMUX_PKG_BUILDDIR/* $TL_ROOT/
+	perl -I$TL_ROOT/tlpkg/ $TL_ROOT/texmf-dist/scripts/texlive/mktexlsr.pl $TL_ROOT/texmf-dist
+	mkdir -p $TL_ROOT/tlpkg
+	cp $TERMUX_PKG_TMPDIR/texlive.tlpdb $TL_ROOT/tlpkg/
+
+	mkdir -p $TERMUX_PREFIX/etc/profile.d
+	echo "export PATH=\$PATH:$TERMUX_PREFIX/bin/texlive" \
+		> $TERMUX_PREFIX/etc/profile.d/texlive.sh
+}
+
+termux_step_create_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/bash" > postinst
+	echo "$TL_ROOT/texmf-dist/scripts/texlive/mktexlsr.pl" >> postinst
+	echo "$TL_ROOT/texmf-dist/scripts/texlive-extra/texlinks.sh" >> postinst
+	echo "echo ''" >> postinst
+	echo "echo Welcome to TeX Live!" >> postinst
+	echo "echo ''" >> postinst
+	echo "echo 'TeX Live is a joint project of the TeX user groups around the world;'" >> postinst
+	echo "echo 'please consider supporting it by joining the group best for you.'" >> postinst
+	echo "echo 'The list of groups is available on the web at http://tug.org/usergroups.html.'" >> postinst
+        echo "echo ''" >> postinst
+        echo "echo 'Now source \$PREFIX/etc/profile.d/texlive.sh or open a new shell to add the'" >> postinst
+        echo "echo 'texlive binaries to \$PATH'" >> postinst
+	echo "exit 0" >> postinst
+	chmod 0755 postinst
+
+	echo "#!$TERMUX_PREFIX/bin/bash" > prerm
+	echo 'if [ $1 != "remove" ]; then exit 0; fi' >> prerm
+	echo "echo Running texlinks --unlink" >> prerm
+	echo "$TL_ROOT/texmf-dist/scripts/texlive-extra/texlinks.sh --unlink" >> prerm
+	echo "exit 0" >> prerm
+	chmod 0755 prerm
+}
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+share/texlive/install-tl
+share/texlive/texmf-dist/scripts/texlive/uninstall-win32.pl
+share/texlive/texmf-dist/scripts/texlive/uninstq.vbs
+share/texlive/texmf-dist/scripts/texlive/tlmgr.pl
+share/texlive/texmf-dist/scripts/texlive/tlmgrgui.pl
+share/texlive/tlpkg/gpg
+share/texlive/tlpkg/installer
+share/texlive/tlpkg/tltcl
+share/texlive/tlpkg/translations
+share/texlive/texmf-dist/doc
+share/texlive/texmf-dist/source
+"
+
+# Here are all the files in collection-wintools: (single quotes due to share/texlive/tlpkg/dviout/UTILITY/dvi$pdf.bat)
+TERMUX_PKG_RM_AFTER_INSTALL+='
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/pdldoc.tex
+share/texlive/tlpkg/dviout/DOC/cmode1.png
+share/texlive/texmf-dist/doc/support/wintools/pdfseparate.pdf
+share/texlive/texmf-dist/doc/support/wintools/fc-query.pdf
+share/texlive/texmf-dist/doc/support/tlaunch/figures/tlaunch_rug.png
+share/texlive/tlpkg/dviout/GRAPHIC/TPIC/tpicdoc.tex
+share/texlive/tlpkg/dviout/dviout.cnt
+share/texlive/tlpkg/dviout/par/p4to1e.pgm
+share/texlive/tlpkg/dviout/DOC/niko.bmp
+share/texlive/tlpkg/dviout/GRAPHIC/COLOR/color.tex
+share/texlive/bin/win32/luajitlatex.exe
+share/texlive/tlpkg/dviout/DOC/dviouttipse.html
+share/texlive/tlpkg/dviout/SAMPLE/slisamp2.tex
+share/texlive/tlpkg/dviout/DOC/cmode2.png
+share/texlive/tlpkg/dviout/DOC/seru.bmp
+share/texlive/bin/win32/type1afm.exe
+share/texlive/tlpkg/dviout/bmc.exe
+share/texlive/tlpkg/dviout/GRAPHIC/PS/sample1.ps
+share/texlive/tlpkg/dviout/par/HG-GyouSho.par
+share/texlive/tlpkg/dviout/DOC/cmode.html
+share/texlive/texmf-dist/doc/support/wintools/pdftoppm.pdf
+share/texlive/texmf-dist/doc/support/wintools/fc-pattern.pdf
+share/texlive/tlpkg/dviout/GRAPHIC/PS/starbrst.ps
+share/texlive/texmf-dist/doc/support/wintools/pdfdetach.pdf
+share/texlive/bin/win32/png22pnm.exe
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/lasersys.lp3
+share/texlive/tlpkg/dviout/DOC/cmode6.png
+share/texlive/tlpkg/dviout/CreateBB.exe
+share/texlive/tlpkg/dviout/par/p4to1.pgm
+share/texlive/texmf-dist/scripts/tlaunch/tlaunchmode.pl
+share/texlive/texmf-dist/doc/support/tlaunch/figures/tlaunch_window.png
+share/texlive/tlpkg/dviout/FONT/winttf.zip
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/dviout.dtx
+share/texlive/tlpkg/dviout/GRAPHIC/PBM/pbmf.sty
+share/texlive/texmf-dist/doc/support/wintools/zip.pdf
+share/texlive/tlpkg/dviout/convedit.exe
+share/texlive/tlpkg/dviout/par/TTfont.par
+share/texlive/tlpkg/dviout/SAMPLE/slisamp4.tex
+share/texlive/bin/win32/tiff2png.exe
+share/texlive/tlpkg/dviout/DOC/lminus.bmp
+share/texlive/bin/win32/pdftotext.exe
+share/texlive/tlpkg/dviout/SPECIAL/demo.tex
+share/texlive/tlpkg/dviout/SPECIAL/src.mac
+share/texlive/tlpkg/dviout/par/dvipskdl.par
+share/texlive/tlpkg/dviout/par/p12wait.pgm
+share/texlive/bin/win32/tif22pnm.exe
+share/texlive/tlpkg/dviout/par/Hidemaru.par
+share/texlive/tlpkg/dviout/UTILITY/test_b5.tex
+share/texlive/tlpkg/dviout/par/DF-GyouSho.par
+share/texlive/bin/win32/gzip.exe
+share/texlive/bin/win32/tomac.exe
+share/texlive/texmf-dist/doc/support/wintools/pdftohtml.pdf
+share/texlive/tlpkg/dviout/par/PKfont.par
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/file241b.p98
+share/texlive/texmf-dist/doc/support/wintools/fc-cache.pdf
+share/texlive/tlpkg/dviout/DOC/fpage.bmp
+share/texlive/tlpkg/dviout/par/p4to1e0.pgm
+share/texlive/texmf-dist/doc/support/wintools/fc-match.pdf
+share/texlive/bin/win32/tlaunch.exe
+share/texlive/tlpkg/dviout/DOC/dviouttips.html
+share/texlive/tlpkg/dviout/UTILITY/test_b5e.tex
+share/texlive/texmf-dist/doc/support/wintools/pdfimages.pdf
+share/texlive/tlpkg/dviout/GRAPHIC/TPIC/linetest.tex
+share/texlive/tlpkg/dviout/UTILITY/dvioute.vfn
+share/texlive/tlpkg/dviout/DOC/dvioutQA.html
+share/texlive/bin/win32/bitmap2eps.exe
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/dviout.ins
+share/texlive/texmf-dist/doc/support/wintools/fc-scan.pdf
+share/texlive/tlpkg/dviout/UTILITY/template
+share/texlive/bin/win32/pdffonts.exe
+share/texlive/tlpkg/dviout/par/p4n0.pgm
+share/texlive/tlpkg/dviout/install.par
+share/texlive/texmf-dist/scripts/bitmap2eps/bitmap2eps.vbs
+share/texlive/texmf-dist/doc/support/wintools/pdftops.pdf
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/color.cfg
+share/texlive/tlpkg/dviout/map/morisawa.map
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/spec.lp3
+share/texlive/tlpkg/dviout/SAMPLE/slisampl.tex
+share/texlive/bin/win32/bmeps.exe
+share/texlive/tlpkg/dviout/DOC/tex_instchk.html
+share/texlive/tlpkg/dviout/GRAPHIC/PS/gssub.exe
+share/texlive/tlpkg/dviout/SPECIAL/srctex.cfg
+share/texlive/texmf-dist/doc/support/wintools/pdftocairo.pdf
+share/texlive/tlpkg/dviout/DOC/hyper.bmp
+share/texlive/tlpkg/dviout/par/HG-KaiSho-PRO.par
+share/texlive/tlpkg/dviout/DOC/present.html
+share/texlive/tlpkg/dviout/GRAPHIC/PS/epsfdoc.tex
+share/texlive/tlpkg/dviout/DOC/testtex.bat
+share/texlive/tlpkg/dviout/par/p4to10.pgm
+share/texlive/texmf-dist/web2c/tlaunch.ini
+share/texlive/tlpkg/dviout/GRAPHIC/bmc/bmc.txt
+share/texlive/tlpkg/dviout/SAMPLE/sample.txt
+share/texlive/texmf-dist/doc/support/tlaunch/Changes
+share/texlive/bin/win32/pdfseparate.exe
+share/texlive/bin/win32/pdfimages.exe
+share/texlive/tlpkg/dviout/readme.txt
+share/texlive/bin/win32/pdfsig.exe
+share/texlive/tlpkg/dviout/HYPERTEX/input9.tex
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/readme
+share/texlive/tlpkg/dviout/DOC/mspmin.png
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/picbox.tex
+share/texlive/tlpkg/dviout/history.txt
+share/texlive/tlpkg/dviout/DOC/kappa.bmp
+share/texlive/tlpkg/dviout/UTILITY/template.pks
+share/texlive/tlpkg/dviout/SPECIAL/presen.sty
+share/texlive/tlpkg/dviout/rawprt.exe
+share/texlive/bin/win32/pdftops.exe
+share/texlive/tlpkg/dviout/GRAPHIC/bmc/createbb.pdf
+share/texlive/tlpkg/dviout/map/gtfonts.map
+share/texlive/texmf-dist/doc/support/tlaunch/README
+share/texlive/tlpkg/dviout/DOC/le.bmp
+share/texlive/tlpkg/dviout/CFG/prtsrc.zip
+share/texlive/tlpkg/dviout/00readme.txt
+share/texlive/bin/win32/todos.exe
+share/texlive/tlpkg/dviout/GRAPHIC/bmc/ifbmc.spi
+share/texlive/tlpkg/dviout/UTILITY/test_org.tex
+share/texlive/tlpkg/dviout/UTILITY/dviout1.vfn
+share/texlive/tlpkg/dviout/map/mojikyo.map
+share/texlive/bin/win32/aftopl.exe
+share/texlive/bin/win32/png2bmp.exe
+share/texlive/bin/win32/unzip.exe
+share/texlive/tlpkg/dviout/dvispce.txt
+share/texlive/tlpkg/dviout/par/WinShell.par
+share/texlive/tlpkg/dviout/HYPERTEX/hyperdvi.tex
+share/texlive/bin/win32/zip.exe
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/lips3.gpd
+share/texlive/tlpkg/dviout/GRAPHIC/PS/pssample.tex
+share/texlive/tlpkg/dviout/UTILITY/template.pk0
+share/texlive/tlpkg/dviout/par/dvicut.par
+share/texlive/tlpkg/dviout/par/dvipdfmr.par
+share/texlive/tlpkg/dviout/propw.exe
+share/texlive/bin/win32/djpeg.exe
+share/texlive/texmf-dist/doc/support/wintools/fc-list.pdf
+share/texlive/tlpkg/dviout/par/EJ-Embed.par
+share/texlive/tlpkg/dviout/par/J-Embed.par
+share/texlive/tlpkg/dviout/install.txt
+share/texlive/tlpkg/dviout/par/fontpath.par
+share/texlive/tlpkg/dviout/FONT/exjfonts.zip
+share/texlive/tlpkg/dviout/SPECIAL/srcspecial.mac
+share/texlive/tlpkg/dviout/par/E-noTT.par
+share/texlive/tlpkg/dviout/DOC/dvi2.bmp
+share/texlive/tlpkg/dviout/CFG/prtcfg.zip
+share/texlive/tlpkg/dviout/dvispc.txt
+share/texlive/texmf-dist/doc/support/wintools/pdfinfo.pdf
+share/texlive/bin/win32/dviout.exe
+share/texlive/tlpkg/dviout/map/ttfexp.map
+share/texlive/bin/win32/gunzip.exe
+share/texlive/tlpkg/dviout/par/dvipdfmxv.par
+share/texlive/tlpkg/dviout/DOC/bpage.bmp
+share/texlive/tlpkg/dviout/DOC/lplus.bmp
+share/texlive/tlpkg/dviout/HYPERTEX/input8.tex
+share/texlive/texmf-dist/doc/support/wintools/unzip.pdf
+share/texlive/tlpkg/dviout/DOC/tex_dvioutw.html
+share/texlive/bin/win32/tlaunchmode.exe
+share/texlive/tlpkg/dviout/FONT/ReadMe.txt
+share/texlive/tlpkg/dviout/GRAPHIC/PS/sample2.ps
+share/texlive/tlpkg/dviout/GRAPHIC/bmc/exbmc.xpi
+share/texlive/tlpkg/dviout/par/Macro0.par
+share/texlive/tlpkg/dviout/par/hiragino.par
+share/texlive/tlpkg/dviout/par/default.par
+share/texlive/bin/win32/pdfunite.exe
+share/texlive/tlpkg/dviout/par/E-TT.par
+share/texlive/tlpkg/dviout/CFG/newcfg.txt
+share/texlive/tlpkg/dviout/par/p4to1o0.pgm
+share/texlive/tlpkg/dviout/optcfg.exe
+share/texlive/tlpkg/dviout/DOC/hung.png
+share/texlive/tlpkg/dviout/srctex.exe
+share/texlive/tlpkg/dviout/DOC/option.bmp
+share/texlive/tlpkg/dviout/dviadd.exe
+share/texlive/texmf-dist/doc/support/tlaunch/tlaunch.pdf
+share/texlive/tlpkg/dviout/par/jvar.par
+share/texlive/tlpkg/dviout/par/wintex.par
+share/texlive/tlpkg/dviout/par/bakoma.par
+share/texlive/tlpkg/dviout/GRAPHIC/PS/sample3.ps
+share/texlive/tlpkg/dviout/HYPERTEX/inputxy.tex
+share/texlive/tlpkg/dviout/SPECIAL/dviout.sty
+share/texlive/tlpkg/dviout/etfdump.exe
+share/texlive/texmf-dist/doc/support/tlaunch/figures/custom_ed.png
+share/texlive/tlpkg/dviout/par/E-Embed.par
+share/texlive/tlpkg/dviout/par/dvispcat.par
+share/texlive/bin/win32/bmp2png.exe
+share/texlive/tlpkg/dviout/DOC/search.bmp
+share/texlive/tlpkg/dviout/GRAPHIC/PS/sample0.ps
+share/texlive/tlpkg/dviout/SAMPLE/slisamp3.tex
+share/texlive/tlpkg/dviout/dvioute.chm
+share/texlive/tlpkg/dviout/map/pttfonts.map
+share/texlive/tlpkg/dviout/GRAPHIC/TPIC/tpic_ext.doc
+share/texlive/tlpkg/dviout/par/WinJFont.par
+share/texlive/tlpkg/dviout/DOC/newmin.png
+share/texlive/tlpkg/dviout/par/p4to1v.pgm
+share/texlive/tlpkg/dviout/par/dvipskdis.par
+share/texlive/tlpkg/dviout/dviout.chm
+share/texlive/tlpkg/dviout/dvioute.cnt
+share/texlive/tlpkg/dviout/map/japanese.map
+share/texlive/tlpkg/dviout/GRAPHIC/TPIC/rtexampl.tex
+share/texlive/tlpkg/dviout/DOC/dvi.html
+share/texlive/tlpkg/dviout/HYPERTEX/myhyper.sty
+share/texlive/tlpkg/dviout/dviout.exe
+share/texlive/tlpkg/dviout/rawprt.txt
+share/texlive/texmf-dist/doc/support/wintools/pdfunite.pdf
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/lasersys.tex
+share/texlive/bin/win32/jbig2.exe
+share/texlive/tlpkg/dviout/PTEX/naochan!.tex
+share/texlive/tlpkg/dviout/par/dvipskpdf.par
+share/texlive/texmf-dist/doc/support/tlaunch/rug.zip
+share/texlive/tlpkg/dviout/par/p24wait.pgm
+share/texlive/bin/win32/cjpeg.exe
+share/texlive/tlpkg/dviout/par/p4to1o.pgm
+share/texlive/tlpkg/dviout/par/dvipsk.par
+share/texlive/texmf-dist/doc/support/tlaunch/COPYING
+share/texlive/tlpkg/dviout/DOC/print.bmp
+share/texlive/tlpkg/dviout/par/p4n.pgm
+share/texlive/tlpkg/dviout/par/dvipdfm.par
+share/texlive/tlpkg/dviout/par/quitpresen.par
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/graphics.cfg
+share/texlive/texmf-dist/doc/support/wintools/fc-validate.pdf
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/readme.eng
+share/texlive/tlpkg/dviout/GRAPHIC/bmc/ifbmc.txt
+share/texlive/bin/win32/tounix.exe
+share/texlive/tlpkg/dviout/GRAPHIC/PDL/spec.tex
+share/texlive/tlpkg/dviout/HYPERTEX/input7.tex
+share/texlive/texmf-dist/doc/support/wintools/pdffonts.pdf
+share/texlive/tlpkg/dviout/DOC/serd.bmp
+share/texlive/texmf-dist/doc/support/wintools/fc-cat.pdf
+share/texlive/tlpkg/dviout/HYPERTEX/keyin.sty
+share/texlive/tlpkg/dviout/chkfont.txt
+share/texlive/tlpkg/dviout/map/ttfonts.map
+share/texlive/bin/win32/pdftoppm.exe
+share/texlive/tlpkg/dviout/GRAPHIC/LATEX2E/dviout.def
+share/texlive/tlpkg/dviout/par/quit.par
+share/texlive/tlpkg/dviout/gen_pk
+share/texlive/tlpkg/dviout/files.txt
+share/texlive/tlpkg/dviout/dvispc.exe
+share/texlive/bin/win32/pdfinfo.exe
+share/texlive/tlpkg/dviout/par/dvispcal.par
+share/texlive/tlpkg/dviout/par/texhelp.par
+share/texlive/texmf-dist/doc/support/wintools/pdftotext.pdf
+share/texlive/texmf-dist/doc/support/wintools/gzip.pdf
+share/texlive/texmf-dist/doc/support/wintools/pdfsig.pdf
+share/texlive/tlpkg/dviout/HYPERTEX/hyper2.tex
+share/texlive/bin/win32/pdftocairo.exe
+share/texlive/tlpkg/dviout/SAMPLE/sample.tex
+share/texlive/tlpkg/dviout/par/dvipskprn.par
+share/texlive/tlpkg/dviout/UTILITY/dviout0.par
+share/texlive/tlpkg/dviout/SPECIAL/ophook.sty
+share/texlive/tlpkg/dviout/par/dvispcap.par
+share/texlive/tlpkg/dviout/SPECIAL/presen.txt
+share/texlive/bin/win32/pdfdetach.exe
+share/texlive/tlpkg/dviout/par/presen.par
+share/texlive/tlpkg/dviout/par/dvispcs.par
+share/texlive/tlpkg/dviout/UTILITY/test_a4.tex
+share/texlive/tlpkg/dviout/DOC/cmode3.png
+share/texlive/tlpkg/dviout/par/dvipskeps.par
+share/texlive/tlpkg/dviout/HYPERTEX/input.tex
+share/texlive/tlpkg/dviout/chkfont.exe
+share/texlive/tlpkg/dviout/ttindex.exe
+share/texlive/tlpkg/dviout/GRAPHIC/PBM/pbmf.doc
+share/texlive/tlpkg/dviout/UTILITY/null.vfn
+share/texlive/texmf-dist/doc/support/tlaunch/tlaunch.tex
+share/texlive/bin/win32/pdftohtml.exe
+share/texlive/tlpkg/dviout/par/dvipdfms.par
+share/texlive/tlpkg/dviout/UTILITY/dvi$pdf.bat
+share/texlive/bin/win32/texview.exe
+share/texlive/tlpkg/dviout/UTILITY/dviout0.vfn
+share/texlive/bin/win32/sam2p.exe
+share/texlive/tlpkg/dviout/propw0.txt'

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_VERSION=20200406
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-texmf.tar.xz
 TERMUX_PKG_SHA256=0aa97e583ecfd488e1dc60ff049fec073c1e22dfe7de30a3e4e8c851bb875a95
-TERMUX_PKG_DEPENDS="perl, texlive-bin (>= 20200406-1)"
+TERMUX_PKG_DEPENDS="perl, texlive-bin (>= 20200406-4)"
 TERMUX_PKG_CONFLICTS="texlive (<< 20170524-5), texlive-bin (<< 20190410), texlive-tlmgr (<< 20190410), texlive-binextra (<= 20190410-2), texlive-langother (<= 20190410-2), texlive-langgerman (<= 20190410-2), texlive-plaingeneric (<= 20190410-2), texlive-fontsrecommended (<= 20190410-2), texlive-latexrecommended (<= 20190410-2), texlive-latexextra (<= 20190410-2), texlive-xetex (<= 20190410-2)"
 TERMUX_PKG_REPLACES="texlive-bin (<< 20190410), texlive-tlmgr (<< 20190410)"
 TERMUX_PKG_BREAKS="texlive-installer"

--- a/packages/texlive/cjk-gs-integrate.pl.patch
+++ b/packages/texlive/cjk-gs-integrate.pl.patch
@@ -1,0 +1,11 @@
+--- ../cjk-gs-integrate.pl.orig	2020-05-01 17:26:10.709915553 +0200
++++ ./texmf-dist/scripts/cjk-gs-integrate/cjk-gs-integrate.pl	2020-05-01 17:28:25.023071451 +0200
+@@ -1937,7 +1937,7 @@
+   my $foundres = '';
+   if (win32()) {
+     # determine tlgs or native gs
+-    chomp(my $foo = `kpsewhich -var-value=SELFAUTOPARENT`);
++    chomp(my $foo = `kpsewhich -var-value=TEXMFROOT`);
+     if ( -d "$foo/tlpkg/tlgs" ) {
+       # should be texlive with tlgs
+       print_debug("Assuming tlgs win32 ...\n");

--- a/packages/texlive/crossrefware.patch
+++ b/packages/texlive/crossrefware.patch
@@ -1,0 +1,72 @@
+diff -u -r ../crossrefware.orig/bbl2bib.pl ./texmf-dist/scripts/crossrefware/bbl2bib.pl
+--- ../crossrefware.orig/bbl2bib.pl	2020-05-01 17:25:50.416609028 +0200
++++ ./texmf-dist/scripts/crossrefware/bbl2bib.pl	2020-05-01 17:28:25.033071437 +0200
+@@ -98,7 +98,7 @@
+ use strict;
+ BEGIN {
+     # find files relative to our installed location within TeX Live
+-    chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++    chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+     if (length($TLMaster)) {
+ 	unshift @INC, "$TLMaster/texmf-dist/scripts/bibtexperllibs";
+     }
+diff -u -r ../crossrefware.orig/bibdoiadd.pl ./texmf-dist/scripts/crossrefware/bibdoiadd.pl
+--- ../crossrefware.orig/bibdoiadd.pl	2020-05-01 17:25:50.416609028 +0200
++++ ./texmf-dist/scripts/crossrefware/bibdoiadd.pl	2020-05-01 17:28:25.043071424 +0200
+@@ -97,7 +97,7 @@
+ use strict;
+ BEGIN {
+     # find files relative to our installed location within TeX Live
+-    chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++    chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+     if (length($TLMaster)) {
+ 	unshift @INC, "$TLMaster/texmf-dist/scripts/bibtexperllibs";
+     }
+diff -u -r ../crossrefware.orig/bibmradd.pl ./texmf-dist/scripts/crossrefware/bibmradd.pl
+--- ../crossrefware.orig/bibmradd.pl	2020-05-01 17:25:50.416609028 +0200
++++ ./texmf-dist/scripts/crossrefware/bibmradd.pl	2020-05-01 17:28:25.036404766 +0200
+@@ -64,7 +64,7 @@
+ use strict;
+ BEGIN {
+     # find files relative to our installed location within TeX Live
+-    chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++    chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+     if (length($TLMaster)) {
+ 	unshift @INC, "$TLMaster/texmf-dist/scripts/bibtexperllibs";
+     }
+diff -u -r ../crossrefware.orig/biburl2doi.pl ./texmf-dist/scripts/crossrefware/biburl2doi.pl
+--- ../crossrefware.orig/biburl2doi.pl	2020-05-01 17:25:50.416609028 +0200
++++ ./texmf-dist/scripts/crossrefware/biburl2doi.pl	2020-05-01 17:28:25.039738095 +0200
+@@ -51,7 +51,7 @@
+ use strict;
+ BEGIN {
+     # find files relative to our installed location within TeX Live
+-    chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++    chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+     if (length($TLMaster)) {
+ 	unshift @INC, "$TLMaster/texmf-dist/scripts/bibtexperllibs";
+     }
+diff -u -r ../crossrefware.orig/bibzbladd.pl ./texmf-dist/scripts/crossrefware/bibzbladd.pl
+--- ../crossrefware.orig/bibzbladd.pl	2020-05-01 17:25:50.416609028 +0200
++++ ./texmf-dist/scripts/crossrefware/bibzbladd.pl	2020-05-01 17:28:25.043071424 +0200
+@@ -64,7 +64,7 @@
+ use strict;
+ BEGIN {
+     # find files relative to our installed location within TeX Live
+-    chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++    chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+     if (length($TLMaster)) {
+ 	unshift @INC, "$TLMaster/texmf-dist/scripts/bibtexperllibs";
+     }
+diff -u -r ../crossrefware.orig/ltx2crossrefxml.pl ./texmf-dist/scripts/crossrefware/ltx2crossrefxml.pl
+--- ../crossrefware.orig/ltx2crossrefxml.pl	2020-05-01 17:25:50.416609028 +0200
++++ ./texmf-dist/scripts/crossrefware/ltx2crossrefxml.pl	2020-05-01 17:28:25.036404766 +0200
+@@ -70,7 +70,7 @@
+ 
+  BEGIN {
+      # find files relative to our installed location within TeX Live
+-     chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++     chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+      if (length($TLMaster)) {
+ 	 unshift @INC, "$TLMaster/texmf-dist/scripts/bibtexperllibs";
+      }

--- a/packages/texlive/fmtutil.cnf.patch
+++ b/packages/texlive/fmtutil.cnf.patch
@@ -1,0 +1,77 @@
+--- ./texmf-dist/web2c/fmtutil.cnf.orig	2020-04-04 10:19:08.467622980 +0200
++++ ./texmf-dist/web2c/fmtutil.cnf	2020-04-04 10:24:19.200301751 +0200
+@@ -43,7 +43,7 @@
+ #
+ # from aleph:
+ aleph aleph - *aleph.ini
+-lamed aleph language.dat *lambda.ini
++#! lamed aleph language.dat *lambda.ini
+ #
+ # from amstex:
+ amstex pdftex - -translate-file=cp227.tcx *amstex.ini
+@@ -68,11 +68,11 @@
+ pdfcsplain luatex - -etex csplain.ini
+ #
+ # from eplain:
+-eplain pdftex language.dat -translate-file=cp227.tcx *eplain.ini
++#! eplain pdftex language.dat -translate-file=cp227.tcx *eplain.ini
+ #
+ # from jadetex:
+-jadetex pdftex language.dat *jadetex.ini
+-pdfjadetex pdftex language.dat *pdfjadetex.ini
++#! jadetex pdftex language.dat *jadetex.ini
++#! pdfjadetex pdftex language.dat *pdfjadetex.ini
+ #
+ # from latex-bin:
+ latex pdftex language.dat -translate-file=cp227.tcx *latex.ini
+@@ -93,8 +93,8 @@
+ luahbtex luahbtex language.def,language.dat.lua luatex.ini
+ #
+ # from luajittex:
+-luajittex luajittex language.def,language.dat.lua luatex.ini
+-luajithbtex luajithbtex language.def,language.dat.lua luatex.ini
++#! luajittex luajittex language.def,language.dat.lua luatex.ini
++#! luajithbtex luajithbtex language.def,language.dat.lua luatex.ini
+ #
+ # from luatex:
+ luatex luatex language.def,language.dat.lua luatex.ini
+@@ -127,12 +127,12 @@
+ pdfetex pdftex language.def -translate-file=cp227.tcx *pdfetex.ini
+ #
+ # from platex:
+-platex eptex language.dat *platex.ini
+-platex-dev eptex language.dat *platex.ini
++#! platex eptex language.dat *platex.ini
++#! platex-dev eptex language.dat *platex.ini
+ #
+ # from ptex:
+ ptex ptex - ptex.ini
+-eptex eptex language.def *eptex.ini
++#! eptex eptex language.def *eptex.ini
+ #
+ # from tex:
+ tex tex - tex.ini
+@@ -141,12 +141,12 @@
+ texsis pdftex - -translate-file=cp227.tcx texsis.ini
+ #
+ # from uplatex:
+-uplatex euptex language.dat *uplatex.ini
+-uplatex-dev euptex language.dat *uplatex.ini
++#! uplatex euptex language.dat *uplatex.ini
++#! uplatex-dev euptex language.dat *uplatex.ini
+ #
+ # from uptex:
+ uptex uptex - uptex.ini
+-euptex euptex language.def *euptex.ini
++#! euptex euptex language.def *euptex.ini
+ #
+ # from xelatex-dev:
+ xelatex-dev xetex language.dat -etex xelatex.ini
+@@ -156,5 +156,5 @@
+ xelatex xetex language.dat -etex xelatex.ini
+ #
+ # from xmltex:
+-xmltex pdftex language.dat *xmltex.ini
+-pdfxmltex pdftex language.dat *pdfxmltex.ini
++#! xmltex pdftex language.dat *xmltex.ini
++#! pdfxmltex pdftex language.dat *pdfxmltex.ini

--- a/packages/texlive/parse_tlpdb.py
+++ b/packages/texlive/parse_tlpdb.py
@@ -18,7 +18,7 @@
 ##  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 def parse_tlpdb_to_dict(tlpdb_path):
-    """Reads given tlpdb database and creates dict with packages and their dependencies and files
+    """Reads given tlpdb database and creates dict with packages, their dependencies and files
     """
 
     with open(tlpdb_path, "r") as f:
@@ -29,14 +29,27 @@ def parse_tlpdb_to_dict(tlpdb_path):
         if not pkg == "":
             pkg_lines = pkg.split("\n")
             pkg_name = pkg_lines[0].split(" ")[1]
-            # We only care about getting all the files so only check for "depend" and files
+            # We only care about files and depends
             pkg_dict[pkg_name] = {"depends" : [], "files" : []}
-            for line in pkg_lines:
-                line_description = line.split(" ")[0]
-                if line_description == "":
-                    pkg_dict[pkg_name]["files"].append(line.split(" ")[1])
-                elif line_description == "depend":
-                    pkg_dict[pkg_name]["depends"].append(line.split(" ")[1])
+            i = 0
+            while i < len(pkg_lines):
+                if pkg_lines[i].split(" ")[0].startswith("runfiles"):
+                    # Start of file list
+                    i += 1
+                    while i < len(pkg_lines) and pkg_lines[i].startswith(" "):
+                        # files starts with space, for example
+                        # " texmf-dist/tex/latex/collref/collref.sty"
+                        pkg_dict[pkg_name]["files"].append(pkg_lines[i].split(" ")[1])
+                        i += 1
+
+                if i == len(pkg_lines):
+                    break
+
+                if pkg_lines[i].split(" ")[0] == "depend":
+                    pkg_dict[pkg_name]["depends"].append(pkg_lines[i].split(" ")[1])
+
+                i += 1
+
     return pkg_dict
 
 def get_files_in_package(package, files_in_package, visited_pkgs, visit_collections=False):
@@ -45,7 +58,6 @@ def get_files_in_package(package, files_in_package, visited_pkgs, visit_collecti
     for f in pkg_dict[package]["files"]:
         files_in_package.append(f)
     for dep in pkg_dict[package]["depends"]:
-        print(dep.split("."))
         if dep.split(".")[-1] == "ARCH":
             # skip arch dependent packages, which we lack since we build our own binaries
             continue
@@ -60,98 +72,206 @@ def get_files_in_package(package, files_in_package, visited_pkgs, visit_collecti
             files_in_package, visited_pkgs = get_files_in_package(dep, files_in_package, visited_pkgs)
     return files_in_package, visited_pkgs
 
-def Files(*args, **kwargs):
-    """Wrapper around function get_files. Prepends "collection-" to package unless prepend_collection=False is passed. Also uses visit_collections=False per default.
+def Files(packages, bool_visit_collections = False):
     """
-    prefix = "collection-"
-    bool_visit_collections = False
-    for k,v in kwargs.items():
-        if k == "prepend_collection" and not v:
-            prefix = ""
-        elif k == "visit_collections" and v:
-            bool_visit_collections = True
-
+    Wrapper around function get_files. Does not visit collections unless bool_.
+    """
     files = []
-    for pkg in args[0]:
-        files += get_files_in_package(prefix+pkg, [], [], visit_collections=bool_visit_collections)[0]
+    for pkg in packages:
+        files += get_files_in_package(pkg, [], [],
+                                      visit_collections=bool_visit_collections)[0]
     return files
 
 def get_conflicting_pkgs(package):
     """Returns list of packages that contain some files that are also found in 'package'.
     These packages should be listed as dependencies.
     """
-    if package in ["basic"]:
+    if package in ["collection-basic"]:
         conflicting_pkgs = []
-    elif package in ["latex"]:
-        conflicting_pkgs = ["basic"]
-    elif package in ["langeuropean", "langenglish", "langfrench", "langgerman",
-                     "binextra", "fontutils", "langarabic", "langgreek",
-                     "langitalian", "langother", "langpolish", "langportuguese",
-                     "langspanish", "metapost", "fontsrecommended", "games",
-                     "luatex", "music", "plaingeneric", "publishers",
-                     "texworks", "wintools"]:
-        conflicting_pkgs = ["basic", "latex"]
-    elif package == "langczechslovak":
-        conflicting_pkgs = ["basic", "latex", "fontsextra", "luatex"]
-    elif package == "langcyrillic":
-        conflicting_pkgs = ["basic", "latex", "fontsextra", "fontsrecommended",
-                "langgreek", "latexrecommended"]
-    elif package == "formatsextra":
-        conflicting_pkgs = ["basic", "latex", "langcyrillic", "mathscience",
-                "fontsrecommended", "plaingeneric"]
-    elif package == "context":
-        conflicting_pkgs = ["basic", "latex", "mathscience", "fontsrecommended",
-                "metapost", "xetex"]
-    elif package == "langjapanese":
-        conflicting_pkgs = ["basic", "latex", "langcjk", "langchinese"]
-    elif package == "langchinese":
-        conflicting_pkgs = ["basic", "latex", "langcjk", "fontutils"]
-    elif package == "bibtexextra":
-        conflicting_pkgs = ["basic", "latex", "binextra"]
-    elif package == "langcjk":
-        conflicting_pkgs = ["basic", "latex", "langother"]
-    elif package == "latexrecommended":
-        conflicting_pkgs = ["basic", "latex", "fontsrecommended", "latexextra", "pictures", "plaingeneric"]
-    elif package == "mathscience":
-        conflicting_pkgs = ["basic", "latex", "langgreek"]
-    elif package == "langkorean":
-        conflicting_pkgs = ["basic", "latex", "langjapanese", "langcjk", "latexrecommended"]
-    elif package == "latexextra":
-        conflicting_pkgs = ["basic", "latex", "fontsextra"]
-    elif package == "humanities":
-        conflicting_pkgs = ["basic", "latex", "latexextra"]
-    elif package == "pictures":
-        conflicting_pkgs = ["basic", "latex", "latexextra"]
-    elif package == "fontsextra":
-        conflicting_pkgs = ["basic", "latex", "plaingeneric"]
-    elif package == "pstricks":
-        conflicting_pkgs = ["basic", "latex", "plaingeneric"]
-    elif package == "xetex":
-        conflicting_pkgs = ["basic", "latex"]
+
+    elif package in ["collection-latex"]:
+        conflicting_pkgs = ["collection-basic"]
+
+    elif package in ["collection-langeuropean",
+                     "collection-langenglish",
+                     "collection-langfrench",
+                     "collection-langgerman",
+                     "collection-binextra",
+                     "collection-fontutils",
+                     "collection-langarabic",
+                     "collection-langgreek",
+                     "collection-langitalian",
+                     "collection-langother",
+                     "collection-langpolish",
+                     "collection-langportuguese",
+                     "collection-langspanish",
+                     "collection-metapost",
+                     "collection-fontsrecommended",
+                     "collection-games",
+                     "collection-luatex",
+                     "collection-music",
+                     "collection-plaingeneric",
+                     "collection-publishers",
+                     "collection-texworks",
+                     "collection-wintools"]:
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex"]
+
+    elif package == "collection-langczechslovak":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-fontsextra",
+                            "collection-luatex"]
+
+    elif package == "collection-langcyrillic":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-fontsextra",
+                            "collection-fontsrecommended",
+                            "collection-langgreek",
+                            "collection-latexrecommended"]
+
+    elif package == "collection-formatsextra":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-langcyrillic",
+                            "collection-mathscience",
+                            "collection-fontsrecommended",
+                            "collection-plaingeneric"]
+
+    elif package == "collection-context":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-mathscience",
+                            "collection-fontsrecommended",
+                            "collection-metapost",
+                            "collection-xetex"]
+
+    elif package == "collection-langjapanese":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-langcjk",
+                            "collection-langchinese"]
+
+    elif package == "collection-langchinese":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-langcjk",
+                            "collection-fontutils"]
+
+    elif package == "collection-bibtexextra":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-binextra"]
+
+    elif package == "collection-langcjk":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-langother"]
+
+    elif package == "collection-latexrecommended":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-fontsrecommended",
+                            "collection-latexextra",
+                            "collection-pictures",
+                            "collection-plaingeneric"]
+
+    elif package == "collection-mathscience":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-langgreek"]
+
+    elif package == "collection-langkorean":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-langjapanese",
+                            "collection-langcjk",
+                            "collection-latexrecommended"]
+
+    elif package == "collection-latexextra":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-fontsextra"]
+
+    elif package == "collection-humanities":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-latexextra"]
+
+    elif package == "collection-pictures":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-latexextra"]
+
+    elif package == "collection-fontsextra":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-plaingeneric",
+                            "noto",
+                            "alegreya",
+                            "montserrat",
+                            "fira",
+                            "lato",
+                            "mpfonts",
+                            "libertine",
+                            "drm",
+                            "poltawski",
+                            "cm-unicode",
+                            "roboto",
+                            "dejavu",
+                            "plex",
+                            "stickstoo",
+                            "ebgaramond",
+                            "ipaex-type1",
+                            "paratype",
+                            "antt",
+                            "cormorantgaramond",
+                            "libertinus-type1"]
+
+    elif package == "collection-pstricks":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex",
+                            "collection-plaingeneric"]
+
+    elif package == "collection-xetex":
+        conflicting_pkgs = ["collection-basic",
+                            "collection-latex"]
+
+    elif not package.startswith("collection-"):
+        conflicting_pkgs = []
     else:
         raise ValueError(sys.argv[1]+" isn't a known package name")
 
     return conflicting_pkgs
 
-import sys
-tlpdb = sys.argv[2]
-pkg_dict = parse_tlpdb_to_dict(tlpdb)
-
-if len(sys.argv) > 2 and sys.argv[-1] == "print_names":
-    """Generate dependencies to put into TERMUX_SUBPKG_DEPENDS"""
-    # Strip latex and basic since those are part of termux package "texlive"
-    pkgs_in_texlive = ["latex", "basic"]
-    dependencies = ["texlive-"+pkg for pkg in get_conflicting_pkgs(sys.argv[1]) if not pkg in pkgs_in_texlive]
-    if len(dependencies) > 0:
-        print("texlive, "+", ".join(dependencies))
+if __name__ == '__main__':
+    import sys
+    tlpdb = sys.argv[2]
+    pkg_dict = parse_tlpdb_to_dict(tlpdb)
+    
+    if len(sys.argv) > 2 and sys.argv[-1] == "print_names":
+        """Generate dependencies to put into TERMUX_SUBPKG_DEPENDS"""
+        # Strip latex and basic since those are part of termux package "texlive"
+        pkgs_in_texlive = ["latex", "basic"]
+        dependencies = ["texlive-"+pkg for pkg in get_conflicting_pkgs(sys.argv[1]) if not pkg in pkgs_in_texlive]
+        if len(dependencies) > 0:
+            print("texlive, "+", ".join(dependencies))
+        else:
+            print("texlive")
     else:
-        print("texlive")
-else:
-    """Print files which should be included in the subpackage"""
-    # The last set of packages are needed to make our texlive package able to
-    # generate pdflatex.fmt and compile a simple LaTeX test file, so they
-    # should be part of texlive.
-    print("\n".join(["share/texlive/"+line for line in
-                     list( set(Files([sys.argv[1]])) -
-                           set(Files(get_conflicting_pkgs(sys.argv[1]))) -
-                           set(Files(["dehyph-exptl", "hyphen-afrikaans", "kpathsea", "amsfonts", "texlive-scripts-extra", "l3backend", "latexconfig", "tex-ini-files"], prepend_collection=False)) )]))
+        """Print files which should be included in the subpackage"""
+        # The last set of packages are needed to make our texlive package able to
+        # generate pdflatex.fmt and compile a simple LaTeX test file, so they
+        # should be part of texlive.
+        print("\n".join(["share/texlive/"+line for line in
+                         list( set(Files([sys.argv[1]])) -
+                               set(Files(get_conflicting_pkgs(sys.argv[1]))) -
+                               set(Files(["dehyph-exptl",
+                                          "hyphen-afrikaans",
+                                          "kpathsea",
+                                          "amsfonts",
+                                          "texlive-scripts-extra",
+                                          "l3backend",
+                                          "latexconfig",
+                                          "tex-ini-files"])) )]))

--- a/packages/texlive/parse_tlpdb.py
+++ b/packages/texlive/parse_tlpdb.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python3
+##
+##  Script to parse texlive.tlpdb and get list of files in a package
+##
+##  Copyright (C) 2019-2020 Henrik Grimler
+##
+##  This program is free software: you can redistribute it and/or modify
+##  it under the terms of the GNU General Public License as published by
+##  the Free Software Foundation, either version 3 of the License, or
+##  (at your option) any later version.
+##
+##  This program is distributed in the hope that it will be useful,
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##  GNU General Public License for more details.
+##
+##  You should have received a copy of the GNU General Public License
+##  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+def parse_tlpdb_to_dict(tlpdb_path):
+    """Reads given tlpdb database and creates dict with packages and their dependencies and files
+    """
+
+    with open(tlpdb_path, "r") as f:
+        packages = f.read().split("\n\n")
+
+    pkg_dict = {}
+    for pkg in packages:
+        if not pkg == "":
+            pkg_lines = pkg.split("\n")
+            pkg_name = pkg_lines[0].split(" ")[1]
+            # We only care about getting all the files so only check for "depend" and files
+            pkg_dict[pkg_name] = {"depends" : [], "files" : []}
+            for line in pkg_lines:
+                line_description = line.split(" ")[0]
+                if line_description == "":
+                    pkg_dict[pkg_name]["files"].append(line.split(" ")[1])
+                elif line_description == "depend":
+                    pkg_dict[pkg_name]["depends"].append(line.split(" ")[1])
+    return pkg_dict
+
+def get_files_in_package(package, files_in_package, visited_pkgs, visit_collections=False):
+    """Prints files in package and then run itself on each dependency. Doesn't visit collections unless argument visit_collections=True is passed.
+    """
+    for f in pkg_dict[package]["files"]:
+        files_in_package.append(f)
+    for dep in pkg_dict[package]["depends"]:
+        print(dep.split("."))
+        if dep.split(".")[-1] == "ARCH":
+            # skip arch dependent packages, which we lack since we build our own binaries
+            continue
+
+        if dep.split("-")[0] == "collection" or visit_collections:
+            # skip collections unless explicitly told to go through them
+            continue
+
+        if not dep in visited_pkgs:
+            # avoid duplicates
+            visited_pkgs.append(dep)
+            files_in_package, visited_pkgs = get_files_in_package(dep, files_in_package, visited_pkgs)
+    return files_in_package, visited_pkgs
+
+def Files(*args, **kwargs):
+    """Wrapper around function get_files. Prepends "collection-" to package unless prepend_collection=False is passed. Also uses visit_collections=False per default.
+    """
+    prefix = "collection-"
+    bool_visit_collections = False
+    for k,v in kwargs.items():
+        if k == "prepend_collection" and not v:
+            prefix = ""
+        elif k == "visit_collections" and v:
+            bool_visit_collections = True
+
+    files = []
+    for pkg in args[0]:
+        files += get_files_in_package(prefix+pkg, [], [], visit_collections=bool_visit_collections)[0]
+    return files
+
+def get_conflicting_pkgs(package):
+    """Returns list of packages that contain some files that are also found in 'package'.
+    These packages should be listed as dependencies.
+    """
+    if package in ["basic"]:
+        conflicting_pkgs = []
+    elif package in ["latex"]:
+        conflicting_pkgs = ["basic"]
+    elif package in ["langeuropean", "langenglish", "langfrench", "langgerman",
+                     "binextra", "fontutils", "langarabic", "langgreek",
+                     "langitalian", "langother", "langpolish", "langportuguese",
+                     "langspanish", "metapost", "fontsrecommended", "games",
+                     "luatex", "music", "plaingeneric", "publishers",
+                     "texworks", "wintools"]:
+        conflicting_pkgs = ["basic", "latex"]
+    elif package == "langczechslovak":
+        conflicting_pkgs = ["basic", "latex", "fontsextra", "luatex"]
+    elif package == "langcyrillic":
+        conflicting_pkgs = ["basic", "latex", "fontsextra", "fontsrecommended",
+                "langgreek", "latexrecommended"]
+    elif package == "formatsextra":
+        conflicting_pkgs = ["basic", "latex", "langcyrillic", "mathscience",
+                "fontsrecommended", "plaingeneric"]
+    elif package == "context":
+        conflicting_pkgs = ["basic", "latex", "mathscience", "fontsrecommended",
+                "metapost", "xetex"]
+    elif package == "langjapanese":
+        conflicting_pkgs = ["basic", "latex", "langcjk", "langchinese"]
+    elif package == "langchinese":
+        conflicting_pkgs = ["basic", "latex", "langcjk", "fontutils"]
+    elif package == "bibtexextra":
+        conflicting_pkgs = ["basic", "latex", "binextra"]
+    elif package == "langcjk":
+        conflicting_pkgs = ["basic", "latex", "langother"]
+    elif package == "latexrecommended":
+        conflicting_pkgs = ["basic", "latex", "fontsrecommended", "latexextra", "pictures", "plaingeneric"]
+    elif package == "mathscience":
+        conflicting_pkgs = ["basic", "latex", "langgreek"]
+    elif package == "langkorean":
+        conflicting_pkgs = ["basic", "latex", "langjapanese", "langcjk", "latexrecommended"]
+    elif package == "latexextra":
+        conflicting_pkgs = ["basic", "latex", "fontsextra"]
+    elif package == "humanities":
+        conflicting_pkgs = ["basic", "latex", "latexextra"]
+    elif package == "pictures":
+        conflicting_pkgs = ["basic", "latex", "latexextra"]
+    elif package == "fontsextra":
+        conflicting_pkgs = ["basic", "latex", "plaingeneric"]
+    elif package == "pstricks":
+        conflicting_pkgs = ["basic", "latex", "plaingeneric"]
+    elif package == "xetex":
+        conflicting_pkgs = ["basic", "latex"]
+    else:
+        raise ValueError(sys.argv[1]+" isn't a known package name")
+
+    return conflicting_pkgs
+
+import sys
+tlpdb = sys.argv[2]
+pkg_dict = parse_tlpdb_to_dict(tlpdb)
+
+if len(sys.argv) > 2 and sys.argv[-1] == "print_names":
+    """Generate dependencies to put into TERMUX_SUBPKG_DEPENDS"""
+    # Strip latex and basic since those are part of termux package "texlive"
+    pkgs_in_texlive = ["latex", "basic"]
+    dependencies = ["texlive-"+pkg for pkg in get_conflicting_pkgs(sys.argv[1]) if not pkg in pkgs_in_texlive]
+    if len(dependencies) > 0:
+        print("texlive, "+", ".join(dependencies))
+    else:
+        print("texlive")
+else:
+    """Print files which should be included in the subpackage"""
+    # The last set of packages are needed to make our texlive package able to
+    # generate pdflatex.fmt and compile a simple LaTeX test file, so they
+    # should be part of texlive.
+    print("\n".join(["share/texlive/"+line for line in
+                     list( set(Files([sys.argv[1]])) -
+                           set(Files(get_conflicting_pkgs(sys.argv[1]))) -
+                           set(Files(["dehyph-exptl", "hyphen-afrikaans", "kpathsea", "amsfonts", "texlive-scripts-extra", "l3backend", "latexconfig", "tex-ini-files"], prepend_collection=False)) )]))

--- a/packages/texlive/pdfjam.patch
+++ b/packages/texlive/pdfjam.patch
@@ -1,0 +1,20 @@
+--- ../pdfjam.orig	2020-04-04 09:23:16.198017919 +0200
++++ ./texmf-dist/scripts/pdfjam/pdfjam	2020-04-04 09:24:36.684519772 +0200
+@@ -21,7 +21,7 @@
+ ##  The path searched for site-wide configuration files can be set     ##
+ ##  by editing the following variable:                                 ##
+ ##                                                                     ##
+-    configpath='/etc:/usr/share/etc:/usr/local/share:/usr/local/etc'   ##
++    configpath='@TERMUX_PREFIX@/etc:@TERMUX_PREFIX@/share/etc:/usr/local/share:/usr/local/etc'   ##
+ ##                                                                     ##
+ ##  Nothing else in this file should need to be changed.               ##
+ ##                                                                     ##
+@@ -361,7 +361,7 @@
+ ##
+ ##  Next a permitted location for temporary files on your system:
+ ##
+-tempfileDir='/var/tmp'   ##  /var/tmp is standard on most unix systems
++tempfileDir='$PREFIX/tmp'   ##  /var/tmp is standard on most unix systems
+ ##
+ ##
+ ##  Default for the output file location:

--- a/packages/texlive/pedigree.pl.patch
+++ b/packages/texlive/pedigree.pl.patch
@@ -1,0 +1,11 @@
+--- ../pedigree.pl.orig	2020-05-01 17:26:30.863222262 +0200
++++ ./texmf-dist/scripts/pedigree-perl/pedigree.pl	2020-05-01 17:28:24.936404899 +0200
+@@ -110,7 +110,7 @@
+ 
+ BEGIN {
+     # find files relative to our installed location within TeX Live
+-    chomp(my $TLMaster = `kpsewhich -var-value=SELFAUTOPARENT`); # TL root
++    chomp(my $TLMaster = `kpsewhich -var-value=TEXMFROOT`); # TL root
+     if (length($TLMaster)) {
+ 	unshift @INC, "$TLMaster/texmf-dist/scripts/pedigree-perl";
+ 	$TLCONF = "$TLMaster/texmf-config/pedigree/pedigree.cfg";

--- a/packages/texlive/texconfig.sh.patch
+++ b/packages/texlive/texconfig.sh.patch
@@ -1,0 +1,13 @@
+--- ../texconfig.sh.orig	2020-04-04 09:33:30.373390496 +0200
++++ ./texmf-dist/scripts/texlive-extra/texconfig.sh	2020-04-04 09:34:14.749963681 +0200
+@@ -53,8 +53,8 @@
+   case $FMT in
+     "") 
+       FMT=fmt
+-      test ! -x /bin/fmt && test ! -f /usr/bin/fmt &&
+-        { test -x /bin/adjust || test -x /usr/bin/adjust; } && FMT=adjust
++      test ! -x /bin/fmt && test ! -f @TERMUX_PREFIX@/bin/fmt &&
++        { test -x /bin/adjust || test -x @TERMUX_PREFIX@/bin/adjust; } && FMT=adjust
+       ;;
+     *)
+       return

--- a/packages/texlive/texdef.pl.patch
+++ b/packages/texlive/texdef.pl.patch
@@ -1,0 +1,11 @@
+--- ../texdef.pl.orig	2020-04-04 09:27:54.747454581 +0200
++++ ./texmf-dist/scripts/texdef/texdef.pl	2020-04-04 09:28:20.700734760 +0200
+@@ -283,7 +283,7 @@
+             $EDITOR = 'texworks "%f"';
+         }
+         else {
+-            for my $ed (qw(/usr/bin/vim /usr/bin/emacs /usr/bin/nano)) {
++            for my $ed (qw(@TERMUX_PREFIX@/bin/vim @TERMUX_PREFIX@/bin/emacs @TERMUX_PREFIX@/bin/nano)) {
+                 if (-x $ed) {
+                     $EDITOR = $ed;
+                     last;

--- a/packages/texlive/texlive-alegreya.subpackage.sh
+++ b/packages/texlive/texlive-alegreya.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's alegreya package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py alegreya $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-antt.subpackage.sh
+++ b/packages/texlive/texlive-antt.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's antt package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py antt $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-bibtexextra.subpackage.sh
+++ b/packages/texlive/texlive-bibtexextra.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-bibtexextra"
+TERMUX_SUBPKG_DEPENDS="texlive-binextra"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py bibtexextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-bibtexextra.subpackage.sh
+++ b/packages/texlive/texlive-bibtexextra.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-bibtexextra"
 TERMUX_SUBPKG_DEPENDS="texlive-binextra"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py bibtexextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-bibtexextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-binextra.subpackage.sh
+++ b/packages/texlive/texlive-binextra.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-binextra"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py binextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-binextra.subpackage.sh
+++ b/packages/texlive/texlive-binextra.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-binextra"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py binextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-binextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-cm-unicode.subpackage.sh
+++ b/packages/texlive/texlive-cm-unicode.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's cm-unicode package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py cm $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-context.subpackage.sh
+++ b/packages/texlive/texlive-context.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-context"
+TERMUX_SUBPKG_DEPENDS="texlive-mathscience, texlive-fontsrecommended, texlive-metapost, texlive-xetex"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py context $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-context.subpackage.sh
+++ b/packages/texlive/texlive-context.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-context"
 TERMUX_SUBPKG_DEPENDS="texlive-mathscience, texlive-fontsrecommended, texlive-metapost, texlive-xetex"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py context $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-context $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-cormorantgaramond.subpackage.sh
+++ b/packages/texlive/texlive-cormorantgaramond.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's cormorantgaramond package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py cormorantgaramond $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-dejavu.subpackage.sh
+++ b/packages/texlive/texlive-dejavu.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's dejavu package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py dejavu $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-drm.subpackage.sh
+++ b/packages/texlive/texlive-drm.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's drm package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py drm $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-ebgaramond.subpackage.sh
+++ b/packages/texlive/texlive-ebgaramond.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's ebgaramond package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py ebgaramond $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-fira.subpackage.sh
+++ b/packages/texlive/texlive-fira.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's fira package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fira $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-fontsextra.subpackage.sh
+++ b/packages/texlive/texlive-fontsextra.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-fontsextra"
+TERMUX_SUBPKG_DEPENDS="texlive-plaingeneric"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fontsextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410), texlive-latexextra (<= 20190410-2), texlive-fontutils (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-fontsextra.subpackage.sh
+++ b/packages/texlive/texlive-fontsextra.subpackage.sh
@@ -1,6 +1,8 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-fontsextra"
-TERMUX_SUBPKG_DEPENDS="texlive-plaingeneric"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fontsextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+# noto, alegreya, montserrat and so on are splitted out because they together
+# consists of roughly 55 % of the total size of texlive-fontsextra
+TERMUX_SUBPKG_DEPENDS="texlive-plaingeneric, texlive-noto, texlive-alegreya, texlive-montserrat, texlive-fira, texlive-lato, texlive-mpfonts, texlive-libertine, texlive-drm, texlive-poltawski, texlive-cm-unicode, texlive-roboto, texlive-dejavu, texlive-plex, texlive-stickstoo, texlive-ebgaramond, texlive-ipaex-type1, texlive-paratype, texlive-antt, texlive-cormorantgaramond, texlive-libertinus-type1"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-fontsextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410), texlive-latexextra (<= 20190410-2), texlive-fontutils (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-fontsrecommended.subpackage.sh
+++ b/packages/texlive/texlive-fontsrecommended.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-fontsrecommended"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fontsrecommended $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-fontsrecommended.subpackage.sh
+++ b/packages/texlive/texlive-fontsrecommended.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-fontsrecommended"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fontsrecommended $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-fontsrecommended $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-fontutils.subpackage.sh
+++ b/packages/texlive/texlive-fontutils.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-fontutils"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fontutils $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-fontutils.subpackage.sh
+++ b/packages/texlive/texlive-fontutils.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-fontutils"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py fontutils $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-fontutils $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-formatsextra.subpackage.sh
+++ b/packages/texlive/texlive-formatsextra.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-formatsextra"
 TERMUX_SUBPKG_DEPENDS="texlive-langcyrillic, texlive-mathscience, texlive-fontsrecommended, texlive-plaingeneric"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py formatsextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-formatsextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-formatsextra.subpackage.sh
+++ b/packages/texlive/texlive-formatsextra.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-formatsextra"
+TERMUX_SUBPKG_DEPENDS="texlive-langcyrillic, texlive-mathscience, texlive-fontsrecommended, texlive-plaingeneric"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py formatsextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-full.subpackage.sh
+++ b/packages/texlive/texlive-full.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive-full, meta package that depends on all texlive-collections"
+TERMUX_SUBPKG_CONFLICTS="texlive-tlmgr"
+TERMUX_SUBPKG_DEPENDS="texlive-bibtexextra, texlive-binextra, texlive-context, texlive-fontsextra, texlive-fontsrecommended, texlive-fontutils, texlive-formatsextra, texlive-games, texlive-humanities, texlive-langarabic, texlive-langchinese, texlive-langcjk, texlive-langcyrillic, texlive-langczechslovak, texlive-langenglish, texlive-langeuropean, texlive-langfrench, texlive-langgerman, texlive-langgreek, texlive-langitalian, texlive-langjapanese, texlive-langkorean, texlive-langother, texlive-langpolish, texlive-langportuguese, texlive-langspanish, texlive-latexextra, texlive-latexrecommended, texlive-luatex, texlive-mathscience, texlive-metapost, texlive-music, texlive-pictures, texlive-plaingeneric, texlive-pstricks, texlive-publishers, texlive-xetex"
+TERMUX_SUBPKG_INCLUDE="share/texlive/tlpkg/texlive.tlpdb"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-games.subpackage.sh
+++ b/packages/texlive/texlive-games.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-games"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py games $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-games.subpackage.sh
+++ b/packages/texlive/texlive-games.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-games"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py games $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-games $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-humanities.subpackage.sh
+++ b/packages/texlive/texlive-humanities.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-humanities"
 TERMUX_SUBPKG_DEPENDS="texlive-latexextra"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py humanities $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-humanities $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-humanities.subpackage.sh
+++ b/packages/texlive/texlive-humanities.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-humanities"
+TERMUX_SUBPKG_DEPENDS="texlive-latexextra"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py humanities $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-ipaex-type1.subpackage.sh
+++ b/packages/texlive/texlive-ipaex-type1.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's ipaex-type1 package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py ipaex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langarabic.subpackage.sh
+++ b/packages/texlive/texlive-langarabic.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langarabic"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langarabic $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langarabic $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langarabic.subpackage.sh
+++ b/packages/texlive/texlive-langarabic.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langarabic"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langarabic $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langchinese.subpackage.sh
+++ b/packages/texlive/texlive-langchinese.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langchinese"
 TERMUX_SUBPKG_DEPENDS="texlive-langcjk, texlive-fontutils"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langchinese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langchinese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langchinese.subpackage.sh
+++ b/packages/texlive/texlive-langchinese.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langchinese"
+TERMUX_SUBPKG_DEPENDS="texlive-langcjk, texlive-fontutils"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langchinese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langcjk.subpackage.sh
+++ b/packages/texlive/texlive-langcjk.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langcjk"
+TERMUX_SUBPKG_DEPENDS="texlive-langother"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langcjk $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langcjk.subpackage.sh
+++ b/packages/texlive/texlive-langcjk.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langcjk"
 TERMUX_SUBPKG_DEPENDS="texlive-langother"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langcjk $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langcjk $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langcyrillic.subpackage.sh
+++ b/packages/texlive/texlive-langcyrillic.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langcyrillic"
+TERMUX_SUBPKG_DEPENDS="texlive-fontsextra, texlive-fontsrecommended, texlive-langgreek, texlive-latexrecommended"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langcyrillic $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langcyrillic.subpackage.sh
+++ b/packages/texlive/texlive-langcyrillic.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langcyrillic"
 TERMUX_SUBPKG_DEPENDS="texlive-fontsextra, texlive-fontsrecommended, texlive-langgreek, texlive-latexrecommended"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langcyrillic $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langcyrillic $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langczechslovak.subpackage.sh
+++ b/packages/texlive/texlive-langczechslovak.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langczechslovak"
 TERMUX_SUBPKG_DEPENDS="texlive-fontsextra, texlive-luatex"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langczechslovak $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langczechslovak $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langczechslovak.subpackage.sh
+++ b/packages/texlive/texlive-langczechslovak.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langczechslovak"
+TERMUX_SUBPKG_DEPENDS="texlive-fontsextra, texlive-luatex"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langczechslovak $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langenglish.subpackage.sh
+++ b/packages/texlive/texlive-langenglish.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langenglish"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langenglish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langenglish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langenglish.subpackage.sh
+++ b/packages/texlive/texlive-langenglish.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langenglish"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langenglish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langeuropean.subpackage.sh
+++ b/packages/texlive/texlive-langeuropean.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langeuropean"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langeuropean $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langeuropean.subpackage.sh
+++ b/packages/texlive/texlive-langeuropean.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langeuropean"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langeuropean $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langeuropean $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langfrench.subpackage.sh
+++ b/packages/texlive/texlive-langfrench.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langfrench"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langfrench $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langfrench $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langfrench.subpackage.sh
+++ b/packages/texlive/texlive-langfrench.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langfrench"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langfrench $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langgerman.subpackage.sh
+++ b/packages/texlive/texlive-langgerman.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langgerman"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langgerman $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langgerman $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langgerman.subpackage.sh
+++ b/packages/texlive/texlive-langgerman.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langgerman"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langgerman $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langgreek.subpackage.sh
+++ b/packages/texlive/texlive-langgreek.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langgreek"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langgreek $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langgreek.subpackage.sh
+++ b/packages/texlive/texlive-langgreek.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langgreek"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langgreek $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langgreek $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langitalian.subpackage.sh
+++ b/packages/texlive/texlive-langitalian.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langitalian"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langitalian $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langitalian $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langitalian.subpackage.sh
+++ b/packages/texlive/texlive-langitalian.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langitalian"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langitalian $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langjapanese.subpackage.sh
+++ b/packages/texlive/texlive-langjapanese.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langjapanese"
 TERMUX_SUBPKG_DEPENDS="texlive-langcjk, texlive-langchinese"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langjapanese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langjapanese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410), texlive-luatex (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langjapanese.subpackage.sh
+++ b/packages/texlive/texlive-langjapanese.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langjapanese"
+TERMUX_SUBPKG_DEPENDS="texlive-langcjk, texlive-langchinese"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langjapanese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410), texlive-luatex (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langkorean.subpackage.sh
+++ b/packages/texlive/texlive-langkorean.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langkorean"
 TERMUX_SUBPKG_DEPENDS="texlive-langjapanese, texlive-langcjk, texlive-latexrecommended"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langkorean $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langkorean $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langkorean.subpackage.sh
+++ b/packages/texlive/texlive-langkorean.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langkorean"
+TERMUX_SUBPKG_DEPENDS="texlive-langjapanese, texlive-langcjk, texlive-latexrecommended"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langkorean $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langother.subpackage.sh
+++ b/packages/texlive/texlive-langother.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langother"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langother $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langother.subpackage.sh
+++ b/packages/texlive/texlive-langother.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langother"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langother $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langother $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langpolish.subpackage.sh
+++ b/packages/texlive/texlive-langpolish.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langpolish"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langpolish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langpolish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langpolish.subpackage.sh
+++ b/packages/texlive/texlive-langpolish.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langpolish"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langpolish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langportuguese.subpackage.sh
+++ b/packages/texlive/texlive-langportuguese.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langportuguese"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langportuguese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-langportuguese.subpackage.sh
+++ b/packages/texlive/texlive-langportuguese.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langportuguese"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langportuguese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langportuguese $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langspanish.subpackage.sh
+++ b/packages/texlive/texlive-langspanish.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langspanish"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langspanish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-langspanish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-langspanish.subpackage.sh
+++ b/packages/texlive/texlive-langspanish.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-langspanish"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py langspanish $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-latexextra.subpackage.sh
+++ b/packages/texlive/texlive-latexextra.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-latexextra"
+TERMUX_SUBPKG_DEPENDS="texlive-fontsextra"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py latexextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2), texlive-latexrecommended (<= 20190410-2), texlive-pictures (<= 20190410-2), texlive-luatex (<= 20190410-2), texlive-plaingeneric (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-latexextra.subpackage.sh
+++ b/packages/texlive/texlive-latexextra.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-latexextra"
 TERMUX_SUBPKG_DEPENDS="texlive-fontsextra"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py latexextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-latexextra $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2), texlive-latexrecommended (<= 20190410-2), texlive-pictures (<= 20190410-2), texlive-luatex (<= 20190410-2), texlive-plaingeneric (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-latexrecommended.subpackage.sh
+++ b/packages/texlive/texlive-latexrecommended.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-latexrecommended"
 TERMUX_SUBPKG_DEPENDS="texlive-fontsrecommended, texlive-latexextra, texlive-pictures, texlive-plaingeneric"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py latexrecommended $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-latexrecommended $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-latexrecommended.subpackage.sh
+++ b/packages/texlive/texlive-latexrecommended.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-latexrecommended"
+TERMUX_SUBPKG_DEPENDS="texlive-fontsrecommended, texlive-latexextra, texlive-pictures, texlive-plaingeneric"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py latexrecommended $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-lato.subpackage.sh
+++ b/packages/texlive/texlive-lato.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's lato package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py lato $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-libertine.subpackage.sh
+++ b/packages/texlive/texlive-libertine.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's libertine package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py libertine $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-libertinus-type1.subpackage.sh
+++ b/packages/texlive/texlive-libertinus-type1.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's libertinus-type1 package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py libertinus $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-luatex.subpackage.sh
+++ b/packages/texlive/texlive-luatex.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-luatex"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py luatex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-luatex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2), texlive-fontsrecommended (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-luatex.subpackage.sh
+++ b/packages/texlive/texlive-luatex.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-luatex"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py luatex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2), texlive-fontsrecommended (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-mathscience.subpackage.sh
+++ b/packages/texlive/texlive-mathscience.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-mathscience"
+TERMUX_SUBPKG_DEPENDS="texlive-langgreek"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py mathscience $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-mathscience.subpackage.sh
+++ b/packages/texlive/texlive-mathscience.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-mathscience"
 TERMUX_SUBPKG_DEPENDS="texlive-langgreek"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py mathscience $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-mathscience $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-metapost.subpackage.sh
+++ b/packages/texlive/texlive-metapost.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-metapost"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py metapost $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-metapost $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-metapost.subpackage.sh
+++ b/packages/texlive/texlive-metapost.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-metapost"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py metapost $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-montserrat.subpackage.sh
+++ b/packages/texlive/texlive-montserrat.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's montserrat package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py montserrat $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-mpfonts.subpackage.sh
+++ b/packages/texlive/texlive-mpfonts.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's mpfonts package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py mpfonts $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-music.subpackage.sh
+++ b/packages/texlive/texlive-music.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-music"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py music $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-music.subpackage.sh
+++ b/packages/texlive/texlive-music.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-music"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py music $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-music $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-noto.subpackage.sh
+++ b/packages/texlive/texlive-noto.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's noto package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py noto $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-paratype.subpackage.sh
+++ b/packages/texlive/texlive-paratype.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's paratype package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py paratype $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-pictures.subpackage.sh
+++ b/packages/texlive/texlive-pictures.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-pictures"
 TERMUX_SUBPKG_DEPENDS="texlive-latexextra"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py pictures $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-pictures $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-pictures.subpackage.sh
+++ b/packages/texlive/texlive-pictures.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-pictures"
+TERMUX_SUBPKG_DEPENDS="texlive-latexextra"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py pictures $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-plaingeneric.subpackage.sh
+++ b/packages/texlive/texlive-plaingeneric.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-plaingeneric"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py plaingeneric $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-plaingeneric.subpackage.sh
+++ b/packages/texlive/texlive-plaingeneric.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-plaingeneric"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py plaingeneric $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-plaingeneric $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-plex.subpackage.sh
+++ b/packages/texlive/texlive-plex.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's plex package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py plex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-poltawski.subpackage.sh
+++ b/packages/texlive/texlive-poltawski.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's poltawski package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py poltawski $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-pstricks.subpackage.sh
+++ b/packages/texlive/texlive-pstricks.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-pstricks"
 TERMUX_SUBPKG_DEPENDS="texlive-plaingeneric"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py pstricks $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-pstricks $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410), texlive-latexextra (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-pstricks.subpackage.sh
+++ b/packages/texlive/texlive-pstricks.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-pstricks"
+TERMUX_SUBPKG_DEPENDS="texlive-plaingeneric"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py pstricks $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410), texlive-latexextra (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-publishers.subpackage.sh
+++ b/packages/texlive/texlive-publishers.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-publishers"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py publishers $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-publishers.subpackage.sh
+++ b/packages/texlive/texlive-publishers.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-publishers"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py publishers $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-publishers $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<= 20190410-2)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texlive-roboto.subpackage.sh
+++ b/packages/texlive/texlive-roboto.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's roboto package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py roboto $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-stickstoo.subpackage.sh
+++ b/packages/texlive/texlive-stickstoo.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's stickstoo package"
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py stickstoo $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+termux_step_create_subpkg_debscripts() {
+	echo "#lsTERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-xetex.subpackage.sh
+++ b/packages/texlive/texlive-xetex.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-xetex"
+TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py xetex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
+
+termux_step_create_subpkg_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo mktexlsr >> postinst
+}

--- a/packages/texlive/texlive-xetex.subpackage.sh
+++ b/packages/texlive/texlive-xetex.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="Texlive's collection-xetex"
-TERMUX_SUBPKG_INCLUDE=$(python3 $TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py xetex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
+TERMUX_SUBPKG_INCLUDE=$($TERMUX_PKG_BUILDER_DIR/parse_tlpdb.py collection-xetex $TERMUX_PKG_TMPDIR/texlive.tlpdb)
 TERMUX_SUBPKG_CONFLICTS="texlive-bin (<< 20190410), texlive (<< 20190410)"
 
 termux_step_create_subpkg_debscripts() {

--- a/packages/texlive/texmf.cnf.patch
+++ b/packages/texlive/texmf.cnf.patch
@@ -1,0 +1,39 @@
+--- ./texmf-dist/web2c/texmf.cnf.orig	2020-03-01 23:41:34.000000000 +0100
++++ ./texmf-dist/web2c/texmf.cnf	2020-04-30 09:19:57.748456275 +0200
+@@ -59,7 +59,7 @@
+ % SELFAUTOPARENT (its grandparent = /usr/local/texlive/YYYY), and
+ % SELFAUTOGRANDPARENT (its great-grandparent = /usr/local/texlive).
+ % Sorry for the off-by-one-generation names.
+-TEXMFROOT = $SELFAUTOPARENT
++TEXMFROOT = @TERMUX_PREFIX@/share/texlive
+ 
+ % The main tree of distributed packages and programs:
+ TEXMFDIST = $TEXMFROOT/texmf-dist
+@@ -382,7 +382,7 @@
+ % OSFONTDIR is to provide a convenient hook for allowing TeX to find
+ % fonts installed on the system (outside of TeX).  An empty default
+ % value would add "//" to the search paths, so we give it a dummy value.
+-OSFONTDIR = /please/set/osfontdir/in/the/environment
++OSFONTDIR = @TERMUX_PREFIX@/share/fonts/TTF
+ 
+ % PostScript Type 1 outline fonts.
+ T1FONTS = $TEXMFDOTDIR;$TEXMF/fonts/type1//;$OSFONTDIR//
+@@ -431,7 +431,7 @@
+ PDFTEXCONFIG = $TEXMFDOTDIR;$TEXMF/pdftex/{$progname,}//
+ 
+ % Used by DMP (ditroff-to-mpx), called by makempx -troff.
+-TRFONTS = /usr{/local,}/share/groff/{current/font,site-font}/devps
++TRFONTS = @TERMUX_PREFIX@{/local,}/share/groff/{current/font,site-font}/devps
+ MPSUPPORT = $TEXMFDOTDIR;$TEXMF/metapost/support
+ 
+ % For xdvi to find mime.types and .mailcap, if they do not exist in
+@@ -582,7 +582,8 @@
+ $SELFAUTOPARENT/share/texmf/web2c,\
+ $SELFAUTOPARENT/texmf-local/web2c,\
+ $SELFAUTOPARENT/texmf-dist/web2c,\
+-$SELFAUTOPARENT/texmf/web2c\
++$SELFAUTOPARENT/texmf/web2c,\
++@TERMUX_PREFIX@/share/texlive/texmf/web2c\
+ }
+ %
+ % For reference, here is the old brace-using definition:

--- a/packages/texlive/tlshell.tcl.patch
+++ b/packages/texlive/tlshell.tcl.patch
@@ -1,0 +1,11 @@
+--- ../tlshell.tcl.orig	2020-05-01 17:29:18.643000616 +0200
++++ ./texmf-dist/scripts/tlshell/tlshell.tcl	2020-05-01 17:29:38.669640826 +0200
+@@ -1466,7 +1466,7 @@
+     tk_messageBox -message [__ "No backup directory defined"]
+     return
+   }
+-  set bdir [file join [exec kpsewhich -var-value SELFAUTOPARENT] $bdir]
++  set bdir [file join [exec kpsewhich -var-value TEXMFROOT] $bdir]
+   if {! [file isdirectory $bdir]} {
+     tk_messageBox -message [__ "Backup directory %s does not exist" $bdir]
+     return


### PR DESCRIPTION
Only thing left to do is to split texlive-fontsextra into a couple of subpackages. The package is too large for free bintray accounts (having smaller packages is also more convenient as it decreases number of downloads due to failed download attempts)