### PR TITLE
gdal: add expat support

### DIFF
--- a/packages/gdal/build.sh
+++ b/packages/gdal/build.sh
@@ -4,14 +4,15 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.2.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://download.osgeo.org/gdal/${TERMUX_PKG_VERSION}/gdal-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=6c588b58fcb63ff3f288eb9f02d76791c0955ba9210d98c3abd879c770ae28ea
-TERMUX_PKG_DEPENDS="libc++, openjpeg, libcurl, libtiff, libpng, proj, libiconv, libsqlite, libgeos, libspatialite"
+TERMUX_PKG_DEPENDS="libc++, openjpeg, libcurl, libtiff, libpng, proj, libiconv, libsqlite, libgeos, libspatialite, libexpat"
 TERMUX_PKG_BREAKS="gdal-dev"
 TERMUX_PKG_REPLACES="gdal-dev"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-sqlite3=$TERMUX_PREFIX
 --with-spatialite=$TERMUX_PREFIX
+--with-expat=$TERMUX_PREFIX
 "


### PR DESCRIPTION
Adds expat support to the gdal package. libexpat was already packaged, so all that it needed was a command line switch.