### PR TITLE
osm2pgsql

### DIFF
--- a/packages/osm2pgsql/FindLua.cmake.patch
+++ b/packages/osm2pgsql/FindLua.cmake.patch
@@ -1,0 +1,18 @@
+--- /data/data/com.termux/files/home/.termux-build/osm2pgsql/src/cmake/FindLua.cmake	2021-02-03 10:26:41.000000000 -0500
++++ ./cmake/FindLua.cmake	2021-03-02 00:07:15.583814032 -0500
+@@ -126,14 +126,7 @@
+ unset(_lua_library_names)
+ 
+ if (LUA_LIBRARY)
+-    # include the math library for Unix
+-    if (UNIX AND NOT APPLE AND NOT BEOS)
+-        find_library(LUA_MATH_LIBRARY m)
+-        set(LUA_LIBRARIES "${LUA_LIBRARY};${LUA_MATH_LIBRARY}")
+-    # For Windows and Mac, don't need to explicitly include the math library
+-    else ()
+-        set(LUA_LIBRARIES "${LUA_LIBRARY}")
+-    endif ()
++    set(LUA_LIBRARIES "${LUA_LIBRARY}")
+ endif ()
+ 
+ if (LUA_INCLUDE_DIR AND EXISTS "${LUA_INCLUDE_DIR}/lua.h")

--- a/packages/osm2pgsql/build.sh
+++ b/packages/osm2pgsql/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://osm2pgsql.org/
+TERMUX_PKG_DESCRIPTION="osm2pgsql imports OpenStreetMap (OSM) data into a PostgreSQL/PostGIS database"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.4.1
+TERMUX_PKG_SRCURL=https://github.com/openstreetmap/osm2pgsql/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=33c4817dceed99764b089ead0e8e2f67c4c6675e761772339b635800970e66e2
+TERMUX_PKG_DEPENDS="libexpat, proj, bzip2, zlib, boost, postgresql, lua54"


### PR DESCRIPTION
Adds a package for osm2pgsql, a utility for converting OpenStreetMap files into a Postgres / PostGIS table. It obviously doesn't work unless you build PostGIS yourself as described in #55, but the package builds and runs nonetheless.

It needed a patch to the cmake file that looked for Lua. It gave a very confusing message about not being able to find lua, but the problem actually turned out to be that it couldn't find libm. I don't have much knowledge here, but from a bit of research, it looks like some compilers don't actually have a libm.so, and some do. I'm not actually sure. But it builds without it.